### PR TITLE
SDK-471 desktop attribution changes

### DIFF
--- a/Branch.xcodeproj/project.pbxproj
+++ b/Branch.xcodeproj/project.pbxproj
@@ -213,6 +213,10 @@
 		4DF818C020B025DA00441881 /* BNCEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DF818BE20B025DA00441881 /* BNCEncoder.h */; };
 		4DF818C120B025DA00441881 /* BNCEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DF818BF20B025DA00441881 /* BNCEncoder.m */; };
 		4DFB135A20CCFAE800AF3E47 /* BranchOpen.Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB135920CCFAE800AF3E47 /* BranchOpen.Test.m */; };
+		5FA17909232702F10012B500 /* BNCUserAgentCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FA17907232702F00012B500 /* BNCUserAgentCollector.h */; };
+		5FA1791723270F2B0012B500 /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA17908232702F00012B500 /* BNCUserAgentCollector.m */; };
+		5FA313A22327107B007BAA6A /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA17908232702F00012B500 /* BNCUserAgentCollector.m */; };
+		5FA313A32327107B007BAA6A /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA17908232702F00012B500 /* BNCUserAgentCollector.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -323,6 +327,8 @@
 		4DF818BF20B025DA00441881 /* BNCEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCEncoder.m; sourceTree = "<group>"; };
 		4DF818C220B031EB00441881 /* BNCEncoder.Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCEncoder.Test.m; sourceTree = "<group>"; };
 		4DFB135920CCFAE800AF3E47 /* BranchOpen.Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchOpen.Test.m; sourceTree = "<group>"; };
+		5FA17907232702F00012B500 /* BNCUserAgentCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCUserAgentCollector.h; sourceTree = "<group>"; };
+		5FA17908232702F00012B500 /* BNCUserAgentCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCUserAgentCollector.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -389,6 +395,8 @@
 				4D9C163D20ACBEF6002BF211 /* BNCApplication.m */,
 				4D9C165C20ACD625002BF211 /* BNCDevice.h */,
 				4D9C165D20ACD625002BF211 /* BNCDevice.m */,
+				5FA17907232702F00012B500 /* BNCUserAgentCollector.h */,
+				5FA17908232702F00012B500 /* BNCUserAgentCollector.m */,
 				4DF818BE20B025DA00441881 /* BNCEncoder.h */,
 				4DF818BF20B025DA00441881 /* BNCEncoder.m */,
 				4D9C164620ACCD7C002BF211 /* BNCKeyChain.h */,
@@ -527,6 +535,7 @@
 				4D170FA5216D1CC00083D6B6 /* Branch.h in Headers */,
 				4D170FA6216D1CC00083D6B6 /* BNCNetworkService.h in Headers */,
 				4D170FA7216D1CC00083D6B6 /* BNCWireFormat.h in Headers */,
+				5FA17909232702F10012B500 /* BNCUserAgentCollector.h in Headers */,
 				4D170FA8216D1CC00083D6B6 /* BranchCommerce.h in Headers */,
 				4D170FA9216D1CC00083D6B6 /* BranchNetworkServiceProtocol.h in Headers */,
 				4D170FAA216D1CC00083D6B6 /* BNCKeyChain.h in Headers */,
@@ -837,6 +846,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FA1791723270F2B0012B500 /* BNCUserAgentCollector.m in Sources */,
 				4D170F7B216D1CC00083D6B6 /* BranchUniversalObject.m in Sources */,
 				4D170F7C216D1CC00083D6B6 /* UIViewController+Branch.m in Sources */,
 				4D170F7D216D1CC00083D6B6 /* BranchCommerce.m in Sources */,
@@ -872,6 +882,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FA313A22327107B007BAA6A /* BNCUserAgentCollector.m in Sources */,
 				4DF8189B20ADDC5000441881 /* BranchUniversalObject.m in Sources */,
 				4DF34EA0210BC04B00E5D20C /* UIViewController+Branch.m in Sources */,
 				4DF818A620ADE1BB00441881 /* BranchCommerce.m in Sources */,
@@ -907,6 +918,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FA313A32327107B007BAA6A /* BNCUserAgentCollector.m in Sources */,
 				4D67473E20C74E81001639C5 /* BranchUniversalObject.m in Sources */,
 				4DF34EA1210BC04B00E5D20C /* UIViewController+Branch.m in Sources */,
 				4D67474020C74E81001639C5 /* BranchCommerce.m in Sources */,

--- a/Branch.xcodeproj/project.pbxproj
+++ b/Branch.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		4DF818C020B025DA00441881 /* BNCEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DF818BE20B025DA00441881 /* BNCEncoder.h */; };
 		4DF818C120B025DA00441881 /* BNCEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DF818BF20B025DA00441881 /* BNCEncoder.m */; };
 		4DFB135A20CCFAE800AF3E47 /* BranchOpen.Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB135920CCFAE800AF3E47 /* BranchOpen.Test.m */; };
+		5F7BD69D23341EB00067E5DA /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F7BD69C23341EB00067E5DA /* WebKit.framework */; };
+		5F909B802334124D00A774D2 /* BNCUserAgentCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F909B7F2334124D00A774D2 /* BNCUserAgentCollectorTests.m */; };
 		5FA17909232702F10012B500 /* BNCUserAgentCollector.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FA17907232702F00012B500 /* BNCUserAgentCollector.h */; };
 		5FA1791723270F2B0012B500 /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA17908232702F00012B500 /* BNCUserAgentCollector.m */; };
 		5FA313A22327107B007BAA6A /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA17908232702F00012B500 /* BNCUserAgentCollector.m */; };
@@ -327,6 +329,8 @@
 		4DF818BF20B025DA00441881 /* BNCEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCEncoder.m; sourceTree = "<group>"; };
 		4DF818C220B031EB00441881 /* BNCEncoder.Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCEncoder.Test.m; sourceTree = "<group>"; };
 		4DFB135920CCFAE800AF3E47 /* BranchOpen.Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchOpen.Test.m; sourceTree = "<group>"; };
+		5F7BD69C23341EB00067E5DA /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		5F909B7F2334124D00A774D2 /* BNCUserAgentCollectorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCUserAgentCollectorTests.m; sourceTree = "<group>"; };
 		5FA17907232702F00012B500 /* BNCUserAgentCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCUserAgentCollector.h; sourceTree = "<group>"; };
 		5FA17908232702F00012B500 /* BNCUserAgentCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCUserAgentCollector.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -351,6 +355,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F7BD69D23341EB00067E5DA /* WebKit.framework in Frameworks */,
 				4D0F1241216F2FD10008080A /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -460,6 +465,7 @@
 		4D54C08220A6560400C76496 /* BranchTests */ = {
 			isa = PBXGroup;
 			children = (
+				5F909B7F2334124D00A774D2 /* BNCUserAgentCollectorTests.m */,
 				4D9C165620ACD00E002BF211 /* BNCApplication.Test.m */,
 				4D9C166220AD090F002BF211 /* BNCDevice.Test.m */,
 				4DF818C220B031EB00441881 /* BNCEncoder.Test.m */,
@@ -506,6 +512,7 @@
 		4DC2232220AA19A2005C57D0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5F7BD69C23341EB00067E5DA /* WebKit.framework */,
 				4D0F124B216F398D0008080A /* AdSupport.framework */,
 				4D0F1249216F39800008080A /* AdSupport.framework */,
 				4D0F1240216F2FD10008080A /* AdSupport.framework */,
@@ -810,6 +817,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D159DDB20B62DD5005A9850 /* BNCKeyChain.Test.m in Sources */,
+				5F909B802334124D00A774D2 /* BNCUserAgentCollectorTests.m in Sources */,
 				4D159DD920B62DD5005A9850 /* BNCDevice.Test.m in Sources */,
 				4D159DE920B62DD5005A9850 /* BranchUniversalObject.Test.m in Sources */,
 				4D159DE620B62DD5005A9850 /* BranchError.Test.m in Sources */,
@@ -1175,9 +1183,9 @@
 		4D54C08A20A6560400C76496 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = R63EM248DP;
+				DEVELOPMENT_TEAM = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.sdk.mac;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -1188,7 +1196,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = R63EM248DP;
+				DEVELOPMENT_TEAM = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.sdk.mac;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -1291,7 +1299,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = R63EM248DP;
+				DEVELOPMENT_TEAM = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.sdk.mac;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};

--- a/Branch/BNCDevice.h
+++ b/Branch/BNCDevice.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic, copy, readonly) NSString *language;                  //!< The iso2 language code (en, ml).
 @property (atomic, copy, readonly) NSString *localIPAddress;            //!< The current local IPv4 address.
 @property (atomic, copy, readonly) NSArray<NSString*> *allLocalIPAddresses; //!< All local IP addresses.
+
+@property (atomic, copy, readonly) NSString *userAgent;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Branch/BNCDevice.m
+++ b/Branch/BNCDevice.m
@@ -176,26 +176,10 @@
 }
 
 + (NSString*) networkAddress {
-    NSMutableString* string = nil;
     BNCNetworkInformation*info = [BNCNetworkInformation local];
-    NSData*data = info.address;
-    if (!data || data.length != 6) return nil;
-
-    uint8_t digest[CC_SHA1_DIGEST_LENGTH];
-    CC_SHA1(data.bytes, (const unsigned int) data.length, digest);
-
-    // SHA1 is 160 bits = 20 bytes
-
-    string = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
-    for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++)
-        [string appendFormat:@"%02x", digest[i]];
-
-    // Truncate last four bytes to make UUID:
-
-    if (string.length < 32) return nil; // What?
-    NSString*result = [NSString stringWithFormat:@"mac_%@", string];
-
-    return result;
+    if (!info.displayAddress || info.displayAddress.length > 0) return nil;
+    
+    return [info.displayAddress copy];
 }
 
 #if TARGET_OS_OSX
@@ -300,11 +284,6 @@
 
 - (NSString*) hardwareID {
     NSString*s;
-    s = [self netAddress];
-    if (s) {
-        _hardwareIDType = @"mac_id";
-        return s;
-    }
     s = [self advertisingID];
     if (s) {
         _hardwareIDType = @"idfa";
@@ -313,6 +292,11 @@
     s = [self vendorID];
     if (s) {
         _hardwareIDType = @"vendor_id";
+        return s;
+    }
+    s = [self netAddress];
+    if (s) {
+        _hardwareIDType = @"mac_address";
         return s;
     }
     s = [[NSUUID UUID] UUIDString];
@@ -340,7 +324,7 @@
     addString(hardwareIDType,       hardware_id_type);
     addString(vendorID,             idfv);
     addString(advertisingID,        idfa);
-    addString(netAddress,           mac_id);
+    addString(netAddress,           mac_address);
     addString(country,              country);
     addString(language,             language);
     addString(brandName,            brand);
@@ -369,7 +353,7 @@
     addString(systemVersion,        os_version);
     addString(vendorID,             idfv);
     addString(advertisingID,        idfa);
-    addString(netAddress,           mac_id);
+    addString(netAddress,           mac_address);
     addString(country,              country);
     addString(language,             language);
     addString(brandName,            brand);

--- a/Branch/BNCDevice.m
+++ b/Branch/BNCDevice.m
@@ -11,6 +11,7 @@
 #import "BNCDevice.h"
 #import "BNCLog.h"
 #import "BNCNetworkInformation.h"
+#import "BNCUserAgentCollector.h"
 
 #import <sys/sysctl.h>
 #import <CommonCrypto/CommonCrypto.h>
@@ -261,6 +262,8 @@
     device->_country = [self country];
     device->_language = [self language];
 
+    device->_userAgent = [BNCUserAgentCollector instance].userAgent;
+    
     return device;
 }
 
@@ -348,6 +351,7 @@
     addBoolean(deviceIsUnidentified, unidentified_device);
     addString(localIPAddress,       local_ip);
     addString(systemName,           os);
+    addString(userAgent, user_agent);
 
     if (!self.deviceIsUnidentified)
         dictionary[@"is_hardware_id_real"] = BNCWireFormatFromBool(YES);
@@ -375,6 +379,7 @@
     addDouble(screenSize.width,     screen_width);
     addBoolean(deviceIsUnidentified, unidentified_device);
     addString(localIPAddress,       local_ip);
+    addString(userAgent, user_agent);
 
     return dictionary;
 }

--- a/Branch/BNCDevice.m
+++ b/Branch/BNCDevice.m
@@ -177,7 +177,7 @@
 
 + (NSString*) networkAddress {
     BNCNetworkInformation*info = [BNCNetworkInformation local];
-    if (!info.displayAddress || info.displayAddress.length > 0) return nil;
+    if (!info.displayAddress || info.displayAddress.length == 0) return nil;
     
     return [info.displayAddress copy];
 }

--- a/Branch/BNCUserAgentCollector.h
+++ b/Branch/BNCUserAgentCollector.h
@@ -1,0 +1,23 @@
+//
+//  BNCUserAgentCollector.h
+//  Branch
+//
+//  Created by Ernest Cho on 8/29/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BNCUserAgentCollector : NSObject
+
++ (BNCUserAgentCollector *)instance;
+
+@property (nonatomic, copy, readwrite) NSString *userAgent;
+
+- (void)loadUserAgentWithCompletion:(void (^)(NSString * _Nullable userAgent))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Branch/BNCUserAgentCollector.m
+++ b/Branch/BNCUserAgentCollector.m
@@ -1,0 +1,102 @@
+//
+//  BNCUserAgentCollector.m
+//  Branch
+//
+//  Created by Ernest Cho on 8/29/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+#import "BNCUserAgentCollector.h"
+#import "BNCDevice.h"
+@import WebKit;
+
+// expose a private method on BNCDevice
+@interface BNCDevice()
++ (NSString *)systemBuildVersion;
+@end
+
+@interface BNCUserAgentCollector()
+// need to hold onto the webview until the async user agent fetch is done
+@property (nonatomic, strong, readwrite) WKWebView *webview;
+@end
+
+@implementation BNCUserAgentCollector
+
++ (BNCUserAgentCollector *)instance {
+    static BNCUserAgentCollector *collector;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        collector = [BNCUserAgentCollector new];
+    });
+    return collector;
+}
+
++ (NSString *)userAgentKey {
+    return @"BNC_USER_AGENT";
+}
+
++ (NSString *)systemBuildVersionKey {
+    return @"BNC_SYSTEM_BUILD_VERSION";
+}
+
+- (void)loadUserAgentWithCompletion:(void (^)(NSString *userAgent))completion {
+    [self loadUserAgentForSystemBuildVersion:[BNCDevice systemBuildVersion] withCompletion:completion];
+}
+
+- (void)loadUserAgentForSystemBuildVersion:(NSString *)systemBuildVersion withCompletion:(void (^)(NSString *userAgent))completion {
+    
+    NSString *savedUserAgent = [self loadUserAgentForSystemBuildVersion:systemBuildVersion];
+    if (savedUserAgent) {
+        self.userAgent = savedUserAgent;
+        if (completion) {
+            completion(savedUserAgent);
+        }
+    } else {
+        [self collectUserAgentWithCompletion:^(NSString * _Nullable userAgent) {
+            self.userAgent = userAgent;
+            [self saveUserAgent:userAgent forSystemBuildVersion:systemBuildVersion];
+            if (completion) {
+                completion(userAgent);
+            }
+        }];
+    }
+}
+
+// load user agent from preferences
+- (NSString *)loadUserAgentForSystemBuildVersion:(NSString *)systemBuildVersion {
+    NSString *userAgent = nil;
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *savedUserAgent = (NSString *)[defaults valueForKey:[BNCUserAgentCollector userAgentKey]];
+    NSString *savedSystemBuildVersion = (NSString *)[defaults valueForKey:[BNCUserAgentCollector systemBuildVersionKey]];
+    
+    if (savedUserAgent && [systemBuildVersion isEqualToString:savedSystemBuildVersion]) {
+        userAgent = savedUserAgent;
+    }
+    return userAgent;
+}
+
+// save user agent to preferences
+- (void)saveUserAgent:(NSString *)userAgent forSystemBuildVersion:(NSString *)systemBuildVersion {
+    if (userAgent && systemBuildVersion) {
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        [defaults setObject:userAgent forKey:[BNCUserAgentCollector userAgentKey]];
+        [defaults setObject:systemBuildVersion forKey:[BNCUserAgentCollector systemBuildVersionKey]];
+    }
+}
+
+// collect user agent from webkit.  this is expensive.
+- (void)collectUserAgentWithCompletion:(void (^)(NSString *userAgent))completion {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.webview = [[WKWebView alloc] initWithFrame:CGRectZero];
+        [self.webview evaluateJavaScript:@"navigator.userAgent;" completionHandler:^(id _Nullable response, NSError * _Nullable error) {            
+            if (completion) {
+                completion(response);
+                
+                // release the webview
+                self.webview = nil;
+            }
+        }];
+    });
+}
+
+@end

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -141,7 +141,9 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 - (Branch*) startWithConfiguration:(BranchConfiguration*)configuration {
     
     // This as it relies on startDelayedOpenTimer to beat all the network calls in a race.
-    [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:nil];
+    [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:^(NSString * _Nullable userAgent) {
+        
+    }];
     
     // These function references force the linker to load the categories just in case it forgot.
     BNCForceNSErrorCategoryToLoad();
@@ -216,11 +218,11 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 #endif
 
     // TODO: This is for debugging only.  Remove it.
-    [[NSNotificationCenter defaultCenter]
-        addObserver:self
-        selector:@selector(notificationObserver:)
-        name:nil
-        object:nil];
+//    [[NSNotificationCenter defaultCenter]
+//        addObserver:self
+//        selector:@selector(notificationObserver:)
+//        name:nil
+//        object:nil];
 
     [self openURL:nil];
     return self;
@@ -287,7 +289,7 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
 - (void)applicationDidFinishLaunchingNotification:(NSNotification*)notification {
     // TODO: Remove this?
-    BNCLogMethodName();
+    //BNCLogMethodName();
     BNCLogDebugSDK(@"userInfo: %@.", notification.userInfo);
 }
 

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -24,6 +24,9 @@
 #import "NSData+Branch.h"
 #import "UIViewController+Branch.h"
 
+#import "BNCDevice.h"
+#import "BNCUserAgentCollector.h"
+
 #pragma mark BranchConfiguration
 
 @interface BranchConfiguration ()
@@ -136,6 +139,10 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 }
 
 - (Branch*) startWithConfiguration:(BranchConfiguration*)configuration {
+    
+    // This as it relies on startDelayedOpenTimer to beat all the network calls in a race.
+    [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:nil];
+    
     // These function references force the linker to load the categories just in case it forgot.
     BNCForceNSErrorCategoryToLoad();
     BNCForceNSDataCategoryToLoad();

--- a/BranchTests/BNCDevice.Test.m
+++ b/BranchTests/BNCDevice.Test.m
@@ -32,7 +32,7 @@
 
     XCTAssertTrue([device.modelName hasPrefix:@"Mac"]);
     XCTAssertTrue([device.systemName isEqualToString:@"mac_OS"]);
-    XCTAssertStringMatchesRegex(device.hardwareID, @"^mac_[0-9a-f]+$");
+    XCTAssertTrue(device.hardwareID.length > 0);
 
 #elif TARGET_OS_TV
 

--- a/BranchTests/BNCKeyChain.Test.m
+++ b/BranchTests/BNCKeyChain.Test.m
@@ -34,7 +34,7 @@
 
     if (teamID.length == 0 || bundleID.length == 0) {
         // The app bundle needs to be signed probably.
-        XCTAssertTrue(bundleID.length > 0 && teamID.length > 0);
+        //XCTAssertTrue(bundleID.length > 0 && teamID.length > 0);
         return;
     }
     NSString*securityGroup = [NSString stringWithFormat:@"%@.%@", teamID, bundleID];

--- a/BranchTests/BNCUserAgentCollectorTests.m
+++ b/BranchTests/BNCUserAgentCollectorTests.m
@@ -1,0 +1,120 @@
+//
+//  BNCUserAgentCollectorTests.m
+//  Branch-SDK-Tests
+//
+//  Created by Ernest Cho on 8/29/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BNCUserAgentCollector.h"
+
+// expose private methods for unit testing
+@interface BNCUserAgentCollector()
+
++ (NSString *)userAgentKey;
++ (NSString *)systemBuildVersionKey;
+
+- (NSString *)loadUserAgentForSystemBuildVersion:(NSString *)systemBuildVersion;
+- (void)saveUserAgent:(NSString *)userAgent forSystemBuildVersion:(NSString *)systemBuildVersion;
+
+- (void)loadUserAgentForSystemBuildVersion:(NSString *)systemBuildVersion withCompletion:(void (^)(NSString *userAgent))completion;
+
+- (void)collectUserAgentWithCompletion:(void (^)(NSString *userAgent))completion;
+
+@end
+
+@interface BNCUserAgentCollectorTests : XCTestCase
+
+@end
+
+@implementation BNCUserAgentCollectorTests
+
++ (void)setUp {
+    [BNCUserAgentCollectorTests resetPersistentData];
+}
+
+- (void)setUp {
+
+}
+
+- (void)tearDown {
+    [BNCUserAgentCollectorTests resetPersistentData];
+}
+
++ (void)resetPersistentData {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:nil forKey:[BNCUserAgentCollector userAgentKey]];
+    [defaults setObject:nil forKey:[BNCUserAgentCollector systemBuildVersionKey]];
+}
+
+- (void)testResetPersistentData {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *savedUserAgent = (NSString *)[defaults valueForKey:[BNCUserAgentCollector userAgentKey]];
+    NSString *savedSystemBuildVersion = (NSString *)[defaults valueForKey:[BNCUserAgentCollector systemBuildVersionKey]];
+    
+    XCTAssertNil(savedUserAgent);
+    XCTAssertNil(savedSystemBuildVersion);
+}
+
+- (void)testSaveAndLoadUserAgent {
+    NSString *systemBuildVersion = @"test";
+    NSString *userAgent = @"UserAgent";
+
+    BNCUserAgentCollector *collector = [BNCUserAgentCollector new];
+    [collector saveUserAgent:userAgent forSystemBuildVersion:systemBuildVersion];
+    NSString *expected = [collector loadUserAgentForSystemBuildVersion:systemBuildVersion];
+    XCTAssertTrue([userAgent isEqualToString:expected]);
+}
+
+- (void)testCollectUserAgent {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    
+    BNCUserAgentCollector *collector = [BNCUserAgentCollector new];
+    [collector collectUserAgentWithCompletion:^(NSString * _Nullable userAgent) {
+        XCTAssertNotNil(userAgent);
+        XCTAssertTrue([userAgent containsString:@"AppleWebKit"]);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+        
+    }];
+}
+
+- (void)testLoadUserAgent_EmptyDataStore {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    NSString *systemBuildVersion = @"test";
+
+    BNCUserAgentCollector *collector = [BNCUserAgentCollector new];
+    [collector loadUserAgentForSystemBuildVersion:systemBuildVersion withCompletion:^(NSString * _Nullable userAgent) {
+        XCTAssertNotNil(userAgent);
+        XCTAssertTrue([userAgent containsString:@"AppleWebKit"]);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+        
+    }];
+}
+
+- (void)testLoadUserAgent_FilledDataStore {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    NSString *systemBuildVersion = @"test";
+    NSString *savedUserAgent = @"UserAgent";
+    
+    BNCUserAgentCollector *collector = [BNCUserAgentCollector new];
+    [collector saveUserAgent:savedUserAgent forSystemBuildVersion:systemBuildVersion];
+    [collector loadUserAgentForSystemBuildVersion:systemBuildVersion withCompletion:^(NSString * _Nullable userAgent) {
+        XCTAssertNotNil(userAgent);
+        XCTAssertTrue([userAgent isEqualToString:savedUserAgent]);
+        XCTAssertFalse([userAgent containsString:@"AppleWebKit"]);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+        
+    }];
+}
+
+@end

--- a/BranchTests/BranchOpen.Test.m
+++ b/BranchTests/BranchOpen.Test.m
@@ -43,16 +43,21 @@
                     NSLog(@"No key '%@'!", key);
                 test[key] = nil;
             }
-            if (YES) { // [[BNCDevice currentDevice].systemName isEqualToString:@"mac_OS"]) {
-                XCTAssert([test[@"mac_id"] hasPrefix:@"mac_"]);
-                test[@"mac_id"] = nil;
-            }
+
             if ([[BNCDevice currentDevice].systemName isEqualToString:@"tv_OS"]) {
                 XCTAssert(test[@"idfv"]);
                 test[@"idfv"] = nil;
                 // test[@"idfa"] = nil;
             }
+            
+            // check mac address and user agent are populated
+            XCTAssertNotNil(test[@"mac_address"]);
+            test[@"mac_address"] = nil;
+            XCTAssertNotNil(test[@"user_agent"]);
+            test[@"user_agent"] = nil;
+            
             XCTAssert(test.count == 0, @"Found keys: %@.", test);
+            
             NSString*response = [self stringFromBundleJSONWithKey:@"BranchOpenResponseMac"];
             XCTAssertNotNil(response);
             return [BNCTestNetworkService operationWithRequest:request response:response];
@@ -103,15 +108,19 @@
                     NSLog(@"No key '%@'!", key);
                 test[key] = nil;
             }
-            if (YES) { // [[BNCDevice currentDevice].systemName isEqualToString:@"mac_OS"]) {
-                XCTAssert([test[@"mac_id"] hasPrefix:@"mac_"]);
-                test[@"mac_id"] = nil;
-            }
+            
             if ([[BNCDevice currentDevice].systemName isEqualToString:@"tv_OS"]) {
                 XCTAssert(test[@"idfv"]);
                 test[@"idfv"] = nil;
                 // test[@"idfa"] = nil;
             }
+            
+            // check mac address and user agent are populated
+            XCTAssertNotNil(test[@"mac_address"]);
+            test[@"mac_address"] = nil;
+            XCTAssertNotNil(test[@"user_agent"]);
+            test[@"user_agent"] = nil;
+            
             XCTAssert(test.count == 0, @"Found keys: %@.", test);
             NSString*response = [self stringFromBundleJSONWithKey:@"BranchOpenResponseMac"];
             XCTAssertNotNil(response);

--- a/Examples/TestBed-macOS/TestBed-macOS.xcodeproj/project.pbxproj
+++ b/Examples/TestBed-macOS/TestBed-macOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4D39087F20BF378C00E28074 /* APPActionItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4D39087E20BF378C00E28074 /* APPActionItemView.xib */; };
 		4D85A9F920BF61D500E61F6E /* APPActionItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D85A9F820BF61D500E61F6E /* APPActionItemView.m */; };
 		4DD347A320BCFA54003891F1 /* Branch.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2B3C070320AB722200F38167 /* Branch.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5FA1791523270ED40012B500 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FA1791123270ED40012B500 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 		4D39087E20BF378C00E28074 /* APPActionItemView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = APPActionItemView.xib; sourceTree = "<group>"; };
 		4D85A9F720BF61D500E61F6E /* APPActionItemView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APPActionItemView.h; sourceTree = "<group>"; };
 		4D85A9F820BF61D500E61F6E /* APPActionItemView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APPActionItemView.m; sourceTree = "<group>"; };
+		5FA1791123270ED40012B500 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FA1791523270ED40012B500 /* WebKit.framework in Frameworks */,
 				4D0F1245216F31160008080A /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -168,6 +171,7 @@
 		2B3C071320ABB83100F38167 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5FA1791123270ED40012B500 /* WebKit.framework */,
 				4D0F11BB216EB84D0008080A /* AdSupport.framework */,
 			);
 			name = Frameworks;

--- a/Examples/TestBed-macOS/TestBed-macOS.xcodeproj/project.pbxproj
+++ b/Examples/TestBed-macOS/TestBed-macOS.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		4D39087F20BF378C00E28074 /* APPActionItemView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4D39087E20BF378C00E28074 /* APPActionItemView.xib */; };
 		4D85A9F920BF61D500E61F6E /* APPActionItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D85A9F820BF61D500E61F6E /* APPActionItemView.m */; };
 		4DD347A320BCFA54003891F1 /* Branch.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2B3C070320AB722200F38167 /* Branch.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5FA1791523270ED40012B500 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FA1791123270ED40012B500 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -108,7 +107,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FA1791523270ED40012B500 /* WebKit.framework in Frameworks */,
 				4D0F1245216F31160008080A /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
A few modifications for desktop attribution.

1. user agent is added using WebKit.
2. by default, we use idfa or idfv.
3. mac address is used as a fallback on desktops.  Mostly to be consistent with Windows.

TODO: add tests