### PR TITLE
INTENG-9765 macOS SDK issues 

### DIFF
--- a/Branch/BNCNetworkInformation.m
+++ b/Branch/BNCNetworkInformation.m
@@ -42,7 +42,7 @@
 + (NSString*) etherString:(struct sockaddr_dl*)sdl  {
     if (sdl->sdl_alen) {
         u_char *cp = (u_char *)LLADDR(sdl);
-        return [NSString stringWithFormat:@"%x:%x:%x:%x:%x:%x",
+        return [NSString stringWithFormat:@"%02x:%02x:%02x:%02x:%02x:%02x",
                     cp[0], cp[1], cp[2], cp[3], cp[4], cp[5]];
     }
     return @"";


### PR DESCRIPTION
We failed to pad when converting sockaddr_dl struct data to an NSString.  This leads to an invalid string representation.

Current
`ac:de:48:0:11:22`

Expected
`ac:de:48:00:11:22`
