### PR TITLE
INTENG-9765 ignore the touchbar iBridge interface.

### DIFF
--- a/Branch/BNCDevice.m
+++ b/Branch/BNCDevice.m
@@ -287,18 +287,28 @@
 #endif
 
 - (NSString *)hardwareID {
-    // INTENG-8458 server only wants hardware id and hardware id type for idfa and idfv.
     NSString *s = nil;
     s = [self advertisingID];
     if (s) {
         _hardwareIDType = @"idfa";
         return s;
     }
+    
     s = [self vendorID];
     if (s) {
         _hardwareIDType = @"vendor_id";
         return s;
     }
+    
+    s = [self netAddress];
+    if (s) {
+        _hardwareIDType = @"mac_address";
+        return s;
+    }
+    
+    s = [[NSUUID UUID] UUIDString];
+    _hardwareIDType = @"random";
+    
     return s;
 }
 


### PR DESCRIPTION
On some MacBook Pros the TouchBar iBridge interface is reported first.  This interface has a private address that's the same on every machine.  Ignore it.

Also restore the mac_address and random as a hardware_id options on macOS.