### PR TITLE
CORE-1659 - Added INITIATE_STREAM and CLOSE_STREAM Standard Events.

### DIFF
--- a/Branch/BranchEvent.h
+++ b/Branch/BranchEvent.h
@@ -55,6 +55,12 @@ FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventInvite;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventLogin;
 FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventReserve;
 
+///@name OTT Events
+
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventInitiateStream;
+FOUNDATION_EXPORT BranchStandardEvent _Nonnull BranchStandardEventCompleteStream;
+
+
 typedef NS_ENUM(NSInteger, BranchEventAdType) {
     BranchEventAdTypeNone,
     BranchEventAdTypeBanner,

--- a/Branch/BranchEvent.m
+++ b/Branch/BranchEvent.m
@@ -51,6 +51,11 @@ BranchStandardEvent BranchStandardEventInvite                 = @"INVITE";
 BranchStandardEvent BranchStandardEventLogin                  = @"LOGIN";
 BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
 
+// OTT Events
+
+BranchStandardEvent BranchStandardEventInitiateStream   = @"INITIATE_STREAM";
+BranchStandardEvent BranchStandardEventCompleteStream = @"COMPLETE_STREAM";
+
 #pragma mark - BranchEvent
 
 @interface BranchEvent () {
@@ -188,6 +193,8 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
         BranchStandardEventStartTrial,
         BranchStandardEventClickAd,
         BranchStandardEventViewAd,
+        BranchStandardEventInitiateStream,
+        BranchStandardEventCompleteStream
     ];
 }
 

--- a/BranchTests/BranchV2Event.Test.m
+++ b/BranchTests/BranchV2Event.Test.m
@@ -278,4 +278,36 @@
 
 }
 
+- (void)testStandardInitiateStreamEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventInitiateStream];
+    event.adType = BranchEventAdTypeBanner;
+    event.contentItems = contentItems;
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"testStandardInitiateStreamEvent"];
+       [branch logEvent:event completion:
+           ^(NSError * _Nullable error) {
+                XCTAssertNil(error);
+                [expectation fulfill];
+           }
+       ];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+}
+
+- (void)testStandardCompleteStreamEvent {
+    BranchEvent *event = [BranchEvent standardEvent:BranchStandardEventCompleteStream];
+    event.adType = BranchEventAdTypeBanner;
+    event.contentItems = contentItems;
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"testStandardCompleteStreamEvent"];
+       [branch logEvent:event completion:
+           ^(NSError * _Nullable error) {
+                XCTAssertNil(error);
+                [expectation fulfill];
+           }
+       ];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+}
+
 @end


### PR DESCRIPTION
Core - 1659 - Added Standard V2 Events INITIATE_STREAM & CLOSE_STREAM.
Added Test Cases for validating these events.