### PR TITLE
[SDK-1530] Add developer_identity to v1/open

### DIFF
--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -129,6 +129,8 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         [metadata addEntriesFromDictionary:self.configuration.settings.requestMetadataDictionary];
         if (metadata.count) dictionary[@"metadata"] = metadata;
         dictionary[@"branch_key"] = self.configuration.key;
+        
+        
     }
 }
 
@@ -199,6 +201,11 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
             BNCLogError(@"Network service error: %@.", operation.error);
             if (completion) completion(operation);
             return;
+        }
+    } else {
+        NSString *endpoint = url.path;
+        if ([endpoint isEqualToString:@"/v1/open"]) {
+            dictionary[@"identity"] = self.settings.userIdentityForDeveloper;
         }
     }
 

--- a/Branch/BNCSettings.m
+++ b/Branch/BNCSettings.m
@@ -210,12 +210,12 @@ static NSString*const _Nonnull BNCSettingsPersistenceName = @"io.branch.sdk.sett
     @synchronized(self) {
         /* Don't clear these:
         self.deviceFingerprintID = nil;
-        self.userIdentity = nil;
         self.identityID = nil;
         self.installParams = nil;
         */
         self.sessionID = nil;
         self.requestMetadataDictionary = nil;
+        self.userIdentityForDeveloper  = nil;
         [self setNeedsSave];
     }
 }


### PR DESCRIPTION
### Description
Adds `developer_identity`/`identity` to v1/open requests. It's already stored and removed from requests when userTrackingDisabled = true.

### Testing
Testing can be done by setting a user identity and then checking the logs when opening the app.  There will be a new `identity` field with the identity as the value.