### PR TITLE
[INTENG-17551] Adding developer_identity to v2/events

### DIFF
--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -147,7 +147,7 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         userData[@"limit_facebook_tracking"] = BNCWireFormatFromBool(self.settings.limitFacebookTracking);
         userData[@"sdk"] = @"mac";
         userData[@"sdk_version"] = Branch.kitDisplayVersion;
-        userData[@"identity"] = self.settings.userIdentityForDeveloper;
+        userData[@"developer_identity"] = self.settings.userIdentityForDeveloper;
         dictionary[@"user_data"] = userData;
 
         // Add metadata:

--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -147,6 +147,7 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         userData[@"limit_facebook_tracking"] = BNCWireFormatFromBool(self.settings.limitFacebookTracking);
         userData[@"sdk"] = @"mac";
         userData[@"sdk_version"] = Branch.kitDisplayVersion;
+        userData[@"identity"] = self.settings.userIdentityForDeveloper;
         dictionary[@"user_data"] = userData;
 
         // Add metadata:
@@ -207,12 +208,6 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         if ([endpoint isEqualToString:@"/v1/open"]) {
             dictionary[@"identity"] = self.settings.userIdentityForDeveloper;
         }
-        
-        if ([endpoint isEqualToString:@"/v2/event/standard"] ||
-            [endpoint isEqualToString:@"/v2/event/custom"]) {
-            dictionary[@"user_data"][@"identity"] = self.settings.userIdentityForDeveloper;
-        }
-        
     }
 
     __weak __typeof(self) weakSelf = self;

--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -207,6 +207,12 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         if ([endpoint isEqualToString:@"/v1/open"]) {
             dictionary[@"identity"] = self.settings.userIdentityForDeveloper;
         }
+        
+        if ([endpoint isEqualToString:@"/v2/event/standard"] ||
+            [endpoint isEqualToString:@"/v2/event/custom"]) {
+            dictionary[@"user_data"][@"identity"] = self.settings.userIdentityForDeveloper;
+        }
+        
     }
 
     __weak __typeof(self) weakSelf = self;


### PR DESCRIPTION
## Reference
INTENG-17551 - SetIdentity() is not working correctly on MacOS

## Summary
This change adds the developer identity to v2/events as `developer_identity` under the `user_data` dictionary.

## Motivation
Previously, MacOS only added developer identity to v1/open requests. Now it is sent on v2/events as well to fix an issue where developer identity wasn't being properly updated on the Branch Dashboard.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Use `setIdentity()` to set a developer identity. Then call a v2/event and check for `developer_identity` under `user_data` in the event's payload.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
