### PR TITLE
Swift 5.8 fix

### DIFF
--- a/Branch/BranchQRCode.m
+++ b/Branch/BranchQRCode.m
@@ -112,7 +112,7 @@ CIImage *qrCodeImage;
             completion:(void(^)(NSData * _Nullable qrCode, NSError * _Nullable error))completion {
     
     NSError *error;
-    NSString *branchAPIURL = [[BranchConfiguration init] branchAPIServiceURL];
+    NSString *branchAPIURL = [[[BranchConfiguration alloc] initWithKey:@""] branchAPIServiceURL];
     NSString *urlString = [NSString stringWithFormat: @"%@/v1/qr-code", branchAPIURL];
     NSURL *url = [NSURL URLWithString: urlString];
     NSURLSession *session = [NSURLSession sharedSession];

--- a/Branch/BranchQRCode.m
+++ b/Branch/BranchQRCode.m
@@ -112,7 +112,7 @@ CIImage *qrCodeImage;
             completion:(void(^)(NSData * _Nullable qrCode, NSError * _Nullable error))completion {
     
     NSError *error;
-    NSString *branchAPIURL = [[BranchConfiguration new] branchAPIServiceURL];
+    NSString *branchAPIURL = [[BranchConfiguration init] branchAPIServiceURL];
     NSString *urlString = [NSString stringWithFormat: @"%@/v1/qr-code", branchAPIURL];
     NSURL *url = [NSURL URLWithString: urlString];
     NSURLSession *session = [NSURLSession sharedSession];


### PR DESCRIPTION
## Reference
[Issue 36](https://github.com/BranchMetrics/mac-branch-deep-linking/issues/36)

## Summary
With Xcode 14.3, Apple introduced Swift 5.8. This has broken Branch SDK because `new` has become unavailable to `BranchConfiguration`.

## Motivation
This fixes the bug by replacing `new` with `init`.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Use Xcode 14.3, build project.
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
