### PR TITLE
SDK-1905-Fix

### DIFF
--- a/Branch/BranchQRCode.m
+++ b/Branch/BranchQRCode.m
@@ -112,7 +112,7 @@ CIImage *qrCodeImage;
             completion:(void(^)(NSData * _Nullable qrCode, NSError * _Nullable error))completion {
     
     NSError *error;
-    NSString *branchAPIURL = [[BranchConfiguration new] branchAPIServiceURL];
+    NSString *branchAPIURL = [[[BranchConfiguration alloc] initWithKey:@""] branchAPIServiceURL];
     NSString *urlString = [NSString stringWithFormat: @"%@/v1/qr-code", branchAPIURL];
     NSURL *url = [NSURL URLWithString: urlString];
     NSURLSession *session = [NSURLSession sharedSession];

--- a/BranchTests/BranchQRCodeTest.m
+++ b/BranchTests/BranchQRCodeTest.m
@@ -36,7 +36,7 @@
 
     if (!branch) {
         branch = Branch.sharedInstance ;
-        BranchConfiguration*configuration = [[BranchConfiguration new] initWithKey:BNCTestBranchKey];
+        BranchConfiguration*configuration = [[BranchConfiguration alloc] initWithKey:BNCTestBranchKey];
         [branch startWithConfiguration:configuration];
     }
 }


### PR DESCRIPTION

## Reference
[SDK-1905] [MacOS] Test MacOS SDK with Xcode 14.3 and Swift 5.8
https://branch.atlassian.net/browse/SDK-1905

## Summary
Replaced new with alloc. BranchConfiguration.init is marked as NS_UNAVAILABLE so new was causing build issues.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Install Xcode 14.3 and update swift version to 5.8 Compile Project. It should build successfully. 
Run tests. 

cc @BranchMetrics/saas-sdk-devs for visibility.


[SDK-1905]: https://branch.atlassian.net/browse/SDK-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ