### PR TITLE
[SDK-2017] Remove v1/profile and v1/logout calls

### DIFF
--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -417,8 +417,6 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
 
     if (self.session.linkCreationURL.length)
         self.settings.linkCreationURL = self.session.linkCreationURL;
-    if (self.session.userIdentityForDeveloper.length)
-        self.settings.userIdentityForDeveloper = self.session.userIdentityForDeveloper;
     if (self.session.sessionID.length)
         self.settings.sessionID = self.session.sessionID;
        

--- a/Branch/BNCNetworkAPIService.m
+++ b/Branch/BNCNetworkAPIService.m
@@ -205,7 +205,7 @@ static NSString*_Nonnull BNCNetworkQueueFilename =  @"io.branch.sdk.network_queu
         }
     } else {
         NSString *endpoint = url.path;
-        if ([endpoint isEqualToString:@"/v1/open"]) {
+        if ([endpoint isEqualToString:@"/v1/open"] || [endpoint isEqualToString:@"/v1/install"]) {
             dictionary[@"identity"] = self.settings.userIdentityForDeveloper;
         }
     }

--- a/Branch/BranchMainClass.h
+++ b/Branch/BranchMainClass.h
@@ -137,18 +137,26 @@ so that Branch can handle the passed URL.
 
 /**
  Set the user's identity to an ID used by your system, so that it is identifiable by you elsewhere. Receive
- a completion callback, notifying you whether it succeeded or failed.
+ a completion callback.
 
  @param   userId      The ID Branch should use to identify this user.
- @param   completion  The callback to be called once the request has completed (success or failure).
+ @param   completion  The callback to be called once the identity has been set.
 
  @warning If you use the same ID between users on different sessions / devices, their actions will be merged.
- @warning This request is not removed from the queue upon failure -- it will be retried until it succeeds.
-          The callback will only ever be called once, though.
  @warning You should call `logout` before calling `setIdentity:` a second time.
 */
 - (void)setUserIdentity:(NSString*)userId
          completion:(void (^_Nullable)(BranchSession*_Nullable session, NSError*_Nullable error))completion;
+
+/**
+ Set the user's identity to an ID used by your system, so that it is identifiable by you elsewhere.
+
+ @param   userId      The ID Branch should use to identify this user.
+
+ @warning If you use the same ID between users on different sessions / devices, their actions will be merged.
+ @warning You should call `logout` before calling `setIdentity:` a second time.
+*/
+- (void)setUserIdentity:(NSString*)userId;
 
 /**
  Retrieve the user identity set via setUserIdentity
@@ -180,6 +188,12 @@ so that Branch can handle the passed URL.
  @warning If the request to logout fails, the session items will not be cleared.
  */
 - (void) logoutWithCompletion:(void (^_Nullable)(NSError*_Nullable error))completion;
+
+/**
+ Clear all of the current user's session items.
+ 
+ */
+- (void) logout;
 
 /**
  Generates a Branch short URL that describes the content described in the Branch Universal Object and

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -613,9 +613,10 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
         session.sessionID = self.settings.sessionID;
         
         self.settings.userIdentityForDeveloper = userID;
+        
+        if (completion) completion(session, nil);
     });
-    
-    if (completion) completion(session, nil);
+
 }
 
 - (nullable NSString *)getUserIdentity {
@@ -640,9 +641,9 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
     BNCPerformBlockOnMainThreadAsync(^{
         self.settings.userIdentityForDeveloper = nil;
+        
+        if (completion) completion(nil);
     });
-    
-    if (completion) completion(nil);
 }
 
 #pragma mark - Miscellaneous

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -586,6 +586,10 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
 #pragma mark - User Identity
 
+- (void)setUserIdentity:(NSString*)userID {
+    [self setUserIdentity:userID completion:nil];
+}
+
 - (void)setUserIdentity:(NSString*)userID
              completion:(void (^_Nullable)(BranchSession*session, NSError*_Nullable error))completion {
     if (!userID || [self.settings.userIdentityForDeveloper isEqualToString:userID]) {
@@ -623,6 +627,10 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
 
 #pragma mark - Logout
+
+- (void)logout {
+    [self logoutWithCompletion:nil];
+}
 
 - (void)logoutWithCompletion:(void (^_Nullable)(NSError*_Nullable))completion {
 

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -592,6 +592,7 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
 - (void)setUserIdentity:(NSString*)userID
              completion:(void (^_Nullable)(BranchSession*session, NSError*_Nullable error))completion {
+    
     if (!userID || [self.settings.userIdentityForDeveloper isEqualToString:userID]) {
         if (completion) completion(nil, nil);   // TODO: fix the session.
         return;
@@ -607,10 +608,12 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
         return;
     }
     
-    session.userIdentityForDeveloper = userID;
-    session.sessionID = self.settings.sessionID;
-    
-    self.settings.userIdentityForDeveloper = userID;
+    BNCPerformBlockOnMainThreadAsync(^{
+        session.userIdentityForDeveloper = userID;
+        session.sessionID = self.settings.sessionID;
+        
+        self.settings.userIdentityForDeveloper = userID;
+    });
     
     if (completion) completion(session, nil);
 }
@@ -627,7 +630,6 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
     return self.configuration.key;
 }
 
-
 #pragma mark - Logout
 
 - (void)logout {
@@ -636,9 +638,11 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 
 - (void)logoutWithCompletion:(void (^_Nullable)(NSError*_Nullable))completion {
 
+    BNCPerformBlockOnMainThreadAsync(^{
         self.settings.userIdentityForDeveloper = nil;
-        
-        if (completion) completion(nil);
+    });
+    
+    if (completion) completion(nil);
 }
 
 #pragma mark - Miscellaneous

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -608,6 +608,8 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
     }
     
     session.userIdentityForDeveloper = userID;
+    session.sessionID = self.settings.sessionID;
+    
     self.settings.userIdentityForDeveloper = userID;
     
     if (completion) completion(session, nil);

--- a/Branch/BranchMainClass.m
+++ b/Branch/BranchMainClass.m
@@ -587,30 +587,26 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 #pragma mark - User Identity
 
 - (void)setUserIdentity:(NSString*)userID
-         completion:(void (^_Nullable)(BranchSession*session, NSError*_Nullable error))completion {
+             completion:(void (^_Nullable)(BranchSession*session, NSError*_Nullable error))completion {
     if (!userID || [self.settings.userIdentityForDeveloper isEqualToString:userID]) {
         if (completion) completion(nil, nil);   // TODO: fix the session.
         return;
     }
-    // [self initSessionIfNeededAndNotInProgress];
-    NSMutableDictionary *dictionary = [NSMutableDictionary new];
-    dictionary[@"identity"] = userID;
-    dictionary[@"randomized_device_token"] = self.settings.randomizedDeviceToken;
-    dictionary[@"session_id"] = self.settings.sessionID;
-    dictionary[@"randomized_bundle_token"] = self.settings.randomizedBundleToken;
-    [self.networkAPIService appendV1APIParametersWithDictionary:dictionary];
-    [self.networkAPIService postOperationForAPIServiceName:@"v1/profile"
-        dictionary:dictionary
-        completion:^(BNCNetworkAPIOperation*_Nonnull operation) {
-            BNCPerformBlockOnMainThreadAsync(^{
-                if (!operation.error) {
-                    self.settings.userIdentityForDeveloper = userID;
-                    operation.session.userIdentityForDeveloper = userID;
-                }
-                if (completion) completion(operation.session, operation.error);
-            });
-        }
-    ];
+    
+    BranchSession *session = [BranchSession new];
+    
+    if (self.settings.userTrackingDisabled) {
+        [self.settings clearUserIdentifyingInformation];
+        NSError *error = [NSError branchErrorWithCode:BNCTrackingDisabledError];
+        BNCLogError(@"Branch error: %@.", error);
+        if (completion) completion(session, error);
+        return;
+    }
+    
+    session.userIdentityForDeveloper = userID;
+    self.settings.userIdentityForDeveloper = userID;
+    
+    if (completion) completion(session, nil);
 }
 
 - (nullable NSString *)getUserIdentity {
@@ -629,18 +625,10 @@ typedef NS_ENUM(NSInteger, BNCSessionState) {
 #pragma mark - Logout
 
 - (void)logoutWithCompletion:(void (^_Nullable)(NSError*_Nullable))completion {
-    NSMutableDictionary *dictionary = [NSMutableDictionary new];
-    dictionary[@"randomized_device_token"] = self.settings.randomizedDeviceToken;
-    dictionary[@"session_id"] = self.settings.sessionID;
-    dictionary[@"randomized_bundle_token"] = self.settings.randomizedBundleToken;
-    [self.networkAPIService appendV1APIParametersWithDictionary:dictionary];
-    [self.networkAPIService postOperationForAPIServiceName:@"v1/logout"
-        dictionary:dictionary
-        completion:^(BNCNetworkAPIOperation * _Nonnull operation) {
-            if (!operation.error)
-                self.settings.userIdentityForDeveloper = nil;
-            BNCPerformBlockOnMainThreadAsync(^{ if (completion) completion(operation.error); });
-        }];
+
+        self.settings.userIdentityForDeveloper = nil;
+        
+        if (completion) completion(nil);
 }
 
 #pragma mark - Miscellaneous

--- a/BranchTests/BNCDevice.Test.m
+++ b/BranchTests/BNCDevice.Test.m
@@ -33,7 +33,7 @@
 
     XCTAssertTrue(
         device.systemVersion.doubleValue > 10.15 &&
-        device.systemVersion.doubleValue <= 13
+        device.systemVersion.doubleValue <= 14
     );
     XCTAssertTrue(BNCTestStringMatchesRegex(device.systemBuildVersion, @"^[0-9A-Za-z]+$"));
     XCTAssertTrue(

--- a/BranchTests/BNCTestNetworkService.Test.m
+++ b/BranchTests/BNCTestNetworkService.Test.m
@@ -17,34 +17,34 @@
 
 @implementation BNCTestNetworkServiceTest
 
-- (void) testTheTestService {
-    BranchConfiguration*config = [[BranchConfiguration alloc] initWithKey:@"key_live_12345"];
-    config.networkServiceClass = [BNCTestNetworkService class];
-    Branch*branch = [[Branch alloc] init];
-    [branch startWithConfiguration:config];
-
-    XCTestExpectation*requestExpectation = [self expectationWithDescription:@"testTheTestService-1"];
-    BNCTestNetworkService.requestHandler = ^ id<BNCNetworkOperationProtocol> (NSMutableURLRequest*request) {
-        XCTAssertEqualObjects(request.HTTPMethod, @"POST");
-        XCTAssertEqualObjects(request.URL.path, @"/v1/logout");
-        NSMutableDictionary*truthDictionary = [self mutableDictionaryFromBundleJSONWithKey:@"logoutRequest"];
-        NSMutableDictionary*requestDictionary = [BNCTestNetworkService mutableDictionaryFromRequest:request];
-        XCTAssertNotNil(truthDictionary);
-        XCTAssertNotNil(requestDictionary);
-
-        [requestExpectation fulfill];
-        NSString*responseString = [self stringFromBundleJSONWithKey:@"logoutResponse"];
-        return [BNCTestNetworkService operationWithRequest:request response:responseString];
-    };
-
-    [branch.networkAPIService clearNetworkQueue];
-    XCTestExpectation*expectation = [self expectationWithDescription:@"testTheTestService-2"];
-    [branch logoutWithCompletion:^(NSError * _Nullable error) {
-        XCTAssertNil(error);
-        [expectation fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-}
+//- (void) testTheTestService {
+//    BranchConfiguration*config = [[BranchConfiguration alloc] initWithKey:@"key_live_12345"];
+//    config.networkServiceClass = [BNCTestNetworkService class];
+//    Branch*branch = [[Branch alloc] init];
+//    [branch startWithConfiguration:config];
+//
+//    XCTestExpectation*requestExpectation = [self expectationWithDescription:@"testTheTestService-1"];
+//    BNCTestNetworkService.requestHandler = ^ id<BNCNetworkOperationProtocol> (NSMutableURLRequest*request) {
+//        XCTAssertEqualObjects(request.HTTPMethod, @"POST");
+//        XCTAssertEqualObjects(request.URL.path, @"/v1/logout");
+//        NSMutableDictionary*truthDictionary = [self mutableDictionaryFromBundleJSONWithKey:@"logoutRequest"];
+//        NSMutableDictionary*requestDictionary = [BNCTestNetworkService mutableDictionaryFromRequest:request];
+//        XCTAssertNotNil(truthDictionary);
+//        XCTAssertNotNil(requestDictionary);
+//
+//        [requestExpectation fulfill];
+//        NSString*responseString = [self stringFromBundleJSONWithKey:@"logoutResponse"];
+//        return [BNCTestNetworkService operationWithRequest:request response:responseString];
+//    };
+//
+//    [branch.networkAPIService clearNetworkQueue];
+//    XCTestExpectation*expectation = [self expectationWithDescription:@"testTheTestService-2"];
+//    [branch logoutWithCompletion:^(NSError * _Nullable error) {
+//        XCTAssertNil(error);
+//        [expectation fulfill];
+//    }];
+//
+//    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+//}
 
 @end

--- a/BranchTests/BNCTestNetworkService.Test.m
+++ b/BranchTests/BNCTestNetworkService.Test.m
@@ -17,34 +17,27 @@
 
 @implementation BNCTestNetworkServiceTest
 
-//- (void) testTheTestService {
-//    BranchConfiguration*config = [[BranchConfiguration alloc] initWithKey:@"key_live_12345"];
-//    config.networkServiceClass = [BNCTestNetworkService class];
-//    Branch*branch = [[Branch alloc] init];
-//    [branch startWithConfiguration:config];
-//
-//    XCTestExpectation*requestExpectation = [self expectationWithDescription:@"testTheTestService-1"];
-//    BNCTestNetworkService.requestHandler = ^ id<BNCNetworkOperationProtocol> (NSMutableURLRequest*request) {
-//        XCTAssertEqualObjects(request.HTTPMethod, @"POST");
-//        XCTAssertEqualObjects(request.URL.path, @"/v1/logout");
-//        NSMutableDictionary*truthDictionary = [self mutableDictionaryFromBundleJSONWithKey:@"logoutRequest"];
-//        NSMutableDictionary*requestDictionary = [BNCTestNetworkService mutableDictionaryFromRequest:request];
-//        XCTAssertNotNil(truthDictionary);
-//        XCTAssertNotNil(requestDictionary);
-//
-//        [requestExpectation fulfill];
-//        NSString*responseString = [self stringFromBundleJSONWithKey:@"logoutResponse"];
-//        return [BNCTestNetworkService operationWithRequest:request response:responseString];
-//    };
-//
-//    [branch.networkAPIService clearNetworkQueue];
-//    XCTestExpectation*expectation = [self expectationWithDescription:@"testTheTestService-2"];
-//    [branch logoutWithCompletion:^(NSError * _Nullable error) {
-//        XCTAssertNil(error);
-//        [expectation fulfill];
-//    }];
-//
-//    [self waitForExpectationsWithTimeout:5.0 handler:nil];
-//}
+- (void) testTheTestService {
+    BranchConfiguration*config = [[BranchConfiguration alloc] initWithKey:@"key_live_12345"];
+    config.networkServiceClass = [BNCTestNetworkService class];
+    Branch*branch = [[Branch alloc] init];
+    [branch startWithConfiguration:config];
+
+    XCTestExpectation*requestExpectation = [self expectationWithDescription:@"testTheTestService-1"];
+    BNCTestNetworkService.requestHandler = ^ id<BNCNetworkOperationProtocol> (NSMutableURLRequest*request) {
+        XCTAssertEqualObjects(request.HTTPMethod, @"POST");
+        XCTAssertEqualObjects(request.URL.path, @"/v1/install");
+        NSMutableDictionary*truthDictionary = [self mutableDictionaryFromBundleJSONWithKey:@"BranchInstallRequestMac"];
+        NSMutableDictionary*requestDictionary = [BNCTestNetworkService mutableDictionaryFromRequest:request];
+        XCTAssertNotNil(truthDictionary);
+        XCTAssertNotNil(requestDictionary);
+
+        [requestExpectation fulfill];
+        NSString*responseString = [self stringFromBundleJSONWithKey:@"BranchOpenResponseMac"];
+        return [BNCTestNetworkService operationWithRequest:request response:responseString];
+    };
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
 
 @end

--- a/BranchTests/BranchMainClass.Test.m
+++ b/BranchTests/BranchMainClass.Test.m
@@ -73,7 +73,7 @@
             [expectation fulfill];
         }
     ];
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    [self waitForExpectationsWithTimeout:0.1 handler:nil];
     XCTAssertTrue(branch.userIdentityIsSet);
 
     [self resetExpectations];
@@ -82,7 +82,7 @@
         XCTAssertNil(error);
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    [self waitForExpectationsWithTimeout:0.1 handler:nil];
     XCTAssertFalse(branch.userIdentityIsSet);
 }
 
@@ -102,7 +102,7 @@
         XCTAssertEqualObjects(session.userIdentityForDeveloper, userIdentity);
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    [self waitForExpectationsWithTimeout:0.1 handler:nil];
     XCTAssertTrue(branch.userIdentityIsSet);
     XCTAssertTrue([userIdentity isEqualToString:[branch getUserIdentity]]);
 }

--- a/BranchTests/BranchMainClass.Test.m
+++ b/BranchTests/BranchMainClass.Test.m
@@ -66,8 +66,7 @@
     NSString*const kUserIdentity = @"Nada";
     Branch*branch = self.branch;
     XCTestExpectation *expectation = [self expectationWithDescription:@"testSetIdentity"];
-    [branch setUserIdentity:kUserIdentity
-        completion:^ (BranchSession * _Nullable session, NSError * _Nullable error) {
+    [branch setUserIdentity:kUserIdentity completion:^ (BranchSession * _Nullable session, NSError * _Nullable error) {
             XCTAssertNil(error);
             XCTAssertEqualObjects(session.userIdentityForDeveloper, kUserIdentity);
             [expectation fulfill];
@@ -149,13 +148,14 @@
     NSString *channel = @"facebook";
     NSString *feature = @"sharing";
     NSArray *tags = @[ @"t1", @"t2" ];
-    NSString *alias =  @"testAlias";
-    
+    NSString *alias = [NSString stringWithFormat:@"testAlias_%@", [NSUUID UUID].UUIDString];
+
     XCTestExpectation *expectation = [self expectationWithDescription:@"testShortLinksWithoutBUO"];
     [self.branch branchShortUrlWithParams:( NSDictionary * _Nullable )params andChannel:( NSString * _Nullable )channel andFeature:(NSString * _Nullable)feature andTags:(NSArray * _Nullable)tags andAlias:(NSString * _Nullable)alias andCallback:^ (NSURL * _Nullable shortURL, NSError * _Nullable error) {
         XCTAssertNil(error);
         XCTAssertNotNil(shortURL);
-        XCTAssertTrue([shortURL.absoluteString isEqualToString:@"https://testbed-mac.app.link/testAlias"]);
+        NSString *expectedURL = [NSString stringWithFormat:@"https://testbed-mac.app.link/%@", alias];
+        XCTAssertTrue([shortURL.absoluteString isEqualToString:expectedURL]);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
@@ -167,13 +167,14 @@
     NSString *channel = @"facebook";
     NSString *feature = @"sharing";
     NSArray *tags = @[ @"t1", @"t2" ];
-    NSString *alias =  @"testAlias";
-    
+    NSString *alias = [NSString stringWithFormat:@"testAlias_%@", [NSUUID UUID].UUIDString];
+
     XCTestExpectation *expectation = [self expectationWithDescription:@"testShortLinksWithoutBUO"];
     [self.branch branchShortUrlWithParams:( NSDictionary * _Nullable )params andChannel:( NSString * _Nullable )channel andFeature:(NSString * _Nullable)feature andTags:(NSArray * _Nullable)tags andAlias:(NSString * _Nullable)alias andCallback:^ (NSURL * _Nullable shortURL, NSError * _Nullable error) {
         XCTAssertNil(error);
         XCTAssertNotNil(shortURL);
-        XCTAssertTrue([shortURL.absoluteString isEqualToString:@"https://testbed-mac.app.link/testAlias"]);
+        NSString *expectedURL = [NSString stringWithFormat:@"https://testbed-mac.app.link/%@", alias];
+        XCTAssertTrue([shortURL.absoluteString isEqualToString:expectedURL]);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];

--- a/Examples/TestBed-macOS/TestBed-macOS/APPActionItemView.xib
+++ b/Examples/TestBed-macOS/TestBed-macOS/APPActionItemView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Examples/TestBed-macOS/TestBed-macOS/APPViewController.m
+++ b/Examples/TestBed-macOS/TestBed-macOS/APPViewController.m
@@ -162,7 +162,7 @@ didSelectItemsAtIndexPaths:(NSSet<NSIndexPath *> *)indexPaths {
     [self clearUIFields];
     [[Branch sharedInstance] setUserIdentity:@"Bob" completion:^ (BranchSession*session, NSError*error) {
         self.stateField.stringValue =
-            [NSString stringWithFormat:@"Set Identity: '%@'", session.userIdentityForDeveloper];
+            [NSString stringWithFormat:@"Set Identity: '%@'", [Branch sharedInstance].getUserIdentity];
         self.errorField.stringValue = [self errorMessage:error];
     }];
 }
@@ -171,7 +171,7 @@ didSelectItemsAtIndexPaths:(NSSet<NSIndexPath *> *)indexPaths {
     BNCLogMethodName();
     [self clearUIFields];
     [[Branch sharedInstance] logoutWithCompletion:^ (NSError*error) {
-        self.stateField.stringValue = @"Log User Out";
+        self.stateField.stringValue = [NSString stringWithFormat:@"Logged User Out: '%@'", [Branch sharedInstance].getUserIdentity];
         self.errorField.stringValue = [self errorMessage:error];
     }];
 }

--- a/Examples/TestBed-macOS/TestBed-macOS/APPViewController.m
+++ b/Examples/TestBed-macOS/TestBed-macOS/APPViewController.m
@@ -160,7 +160,7 @@ didSelectItemsAtIndexPaths:(NSSet<NSIndexPath *> *)indexPaths {
 
 - (IBAction) setIdentity:(id)sender {
     [self clearUIFields];
-    [[Branch sharedInstance] setUserIdentity:@"Bob" completion:^ (BranchSession*session, NSError*error) {
+    [[Branch sharedInstance] setUserIdentity:@"BranchUser123" completion:^ (BranchSession*session, NSError*error) {
         self.stateField.stringValue =
             [NSString stringWithFormat:@"Set Identity: '%@'", [Branch sharedInstance].getUserIdentity];
         self.errorField.stringValue = [self errorMessage:error];


### PR DESCRIPTION
## Reference
SDK-2017 -- [MacOS] Stop calling /v1/profile and /v1/logout

## Summary
Removed the API calls to v1/profile in `setUserIdentity()` and v1/logout in `logout()`. Now these calls are both synchronous and just save the user identity locally. Since user identity is just stored locally, it can passed into each request instead of being handled server side. 

## Motivation
In order to reduce user identity lookups on the backend, we no longer need profile and logout calls. User identity is just handled locally and added to each request to simplify things. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Call the updated setUserIdentity and logout functions and observe that user identity is saved and attached to request properly. 

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
