### PR TITLE
[SDK-2161] Update release announcement to new sdk-releases channel

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Announce New Release in Slack
       uses: slackapi/slack-github-action@v1.24.0
       with:
-        channel-id: "CDFGXRM9S"
+        channel-id: "C063MQJMKJN" #sdk-releases
         payload: |
             {
                 "text": "New Release: Branch MacOS SDK v${{ github.event.release.tag_name }}",


### PR DESCRIPTION
## Reference
SDK-2162 -- Create #sdk-releases channel in Slack

## Summary
Updated the sync-readme-changelog GHA to send the release announcement slack message in the new #sdk-releases channel instead of #sdk.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To make it easier for people to keep track of SDK releases and look back on them.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.